### PR TITLE
Climber gain fix

### DIFF
--- a/src/org/usfirst/frc4904/robot/humaninterface/drivers/NathanGain.java
+++ b/src/org/usfirst/frc4904/robot/humaninterface/drivers/NathanGain.java
@@ -35,7 +35,7 @@ public class NathanGain extends Driver {
 	}
 
 	protected double scaleGain(double input, double gain, double exp) {
-		return Math.pow(input, exp) * gain * Math.signum(input);
+		return Math.pow(Math.abs(input), exp) * gain * Math.signum(input);
 	}
 
 	@Override

--- a/src/org/usfirst/frc4904/robot/humaninterface/drivers/NathanGain.java
+++ b/src/org/usfirst/frc4904/robot/humaninterface/drivers/NathanGain.java
@@ -27,7 +27,7 @@ public class NathanGain extends Driver {
 	public static final double TURN_SPEED_SCALE = 1;
 	public static final double FINE_SCALE = 0.5;
 	public static final double THIRD_GEAR_ENGAGE_DELAY_SECONDS = 0.2;
-	public static final double PASSIVE_CLIMBER_SPIN_SPEED = 0.05;
+	public static final double PASSIVE_CLIMBER_SPIN_SPEED = 0.07;
 	public final EnableableModifier modifier = new EnableableModifier(new LinearModifier(NathanGain.FINE_SCALE));
 	protected final AlignAssist alignAssist = new AlignAssist(HumanInterfaceConfig.gearAlign, modifier);
 

--- a/src/org/usfirst/frc4904/robot/humaninterface/drivers/NathanGain.java
+++ b/src/org/usfirst/frc4904/robot/humaninterface/drivers/NathanGain.java
@@ -66,8 +66,8 @@ public class NathanGain extends Driver {
 		RobotMap.Component.driverXbox.b.whenReleased(normalDrive);
 		RobotMap.Component.teensyStick.getButton(0).whenPressed(normalDrive);
 		// Inverted (airplane-style) analog gain control
-		new Climb(() -> Math.max(0,
-			-scaleGain(RobotMap.Component.driverXbox.rightStick.getY(), NathanGain.CLIMB_GAIN, NathanGain.CLIMB_EXP))).start();
+		RobotMap.Component.driverXbox.x
+			.onlyWhileReleased(new Climb(() -> Math.max(0, -RobotMap.Component.driverXbox.rightStick.getY())));
 		alignAssist.start();
 		HumanInterfaceConfig.autoShifter.start();
 	}

--- a/src/org/usfirst/frc4904/robot/humaninterface/drivers/NathanGain.java
+++ b/src/org/usfirst/frc4904/robot/humaninterface/drivers/NathanGain.java
@@ -27,6 +27,7 @@ public class NathanGain extends Driver {
 	public static final double TURN_SPEED_SCALE = 1;
 	public static final double FINE_SCALE = 0.5;
 	public static final double THIRD_GEAR_ENGAGE_DELAY_SECONDS = 0.2;
+	public static final double PASSIVE_CLIMBER_SPIN_SPEED = 0.05;
 	public final EnableableModifier modifier = new EnableableModifier(new LinearModifier(NathanGain.FINE_SCALE));
 	protected final AlignAssist alignAssist = new AlignAssist(HumanInterfaceConfig.gearAlign, modifier);
 
@@ -68,6 +69,7 @@ public class NathanGain extends Driver {
 		// Inverted (airplane-style) analog gain control
 		RobotMap.Component.driverXbox.x
 			.onlyWhileReleased(new Climb(() -> Math.max(0, -RobotMap.Component.driverXbox.rightStick.getY())));
+		RobotMap.Component.driverXbox.x.onlyWhileHeld(new Climb(() -> NathanGain.PASSIVE_CLIMBER_SPIN_SPEED));
 		alignAssist.start();
 		HumanInterfaceConfig.autoShifter.start();
 	}


### PR DESCRIPTION
This pull request fixes one bug and adds a feature:
1) NathanGain's `scaleGain()` feature now works correctly with odd exponents.
2) The climber will now rotate very slowly unless the x button is pressed, which will make grabbing the rope easier/simpler.