### PR TITLE
Added Wiggle button

### DIFF
--- a/src/org/usfirst/frc4904/robot/ChassisControllerGroup.java
+++ b/src/org/usfirst/frc4904/robot/ChassisControllerGroup.java
@@ -1,0 +1,34 @@
+package org.usfirst.frc4904.robot;
+
+
+import java.util.Arrays;
+import org.usfirst.frc4904.standard.custom.ChassisController;
+
+/**
+ * A composite ChassisController class.
+ * Each ChassisController method returns the sum of the same method called on each component controller.
+ * 
+ * @see ChassisController
+ */
+public class ChassisControllerGroup implements ChassisController {
+	protected ChassisController[] controllers;
+
+	public ChassisControllerGroup(ChassisController... controllers) {
+		this.controllers = controllers;
+	}
+
+	@Override
+	public double getX() {
+		return Arrays.stream(controllers).mapToDouble((ctrlr) -> ctrlr.getX()).sum();
+	}
+
+	@Override
+	public double getY() {
+		return Arrays.stream(controllers).mapToDouble((ctrlr) -> ctrlr.getY()).sum();
+	}
+
+	@Override
+	public double getTurnSpeed() {
+		return Arrays.stream(controllers).mapToDouble((ctrlr) -> ctrlr.getTurnSpeed()).sum();
+	}
+}

--- a/src/org/usfirst/frc4904/robot/humaninterface/drivers/NathanGain.java
+++ b/src/org/usfirst/frc4904/robot/humaninterface/drivers/NathanGain.java
@@ -1,7 +1,9 @@
 package org.usfirst.frc4904.robot.humaninterface.drivers;
 
 
+import org.usfirst.frc4904.robot.ChassisControllerGroup;
 import org.usfirst.frc4904.robot.RobotMap;
+import org.usfirst.frc4904.robot.autonomous.strategies.WiggleApproach;
 import org.usfirst.frc4904.robot.commands.Climb;
 import org.usfirst.frc4904.robot.humaninterface.HumanInterfaceConfig;
 import org.usfirst.frc4904.standard.commands.chassis.ChassisMove;
@@ -51,6 +53,9 @@ public class NathanGain extends Driver {
 		RobotMap.Component.driverXbox.dPad.right.whenReleased(normalDrive);
 		RobotMap.Component.driverXbox.b.onlyWhileHeld(HumanInterfaceConfig.gearAlign);
 		RobotMap.Component.driverXbox.b.whenReleased(normalDrive);
+		RobotMap.Component.driverXbox.y
+			.onlyWhileHeld(new ChassisMove(RobotMap.Component.chassis, new ChassisControllerGroup(this, new WiggleApproach())));
+		RobotMap.Component.driverXbox.y.whenReleased(normalDrive);
 		RobotMap.Component.teensyStick.getButton(0).whenPressed(normalDrive);
 		// Inverted (airplane-style) analog gain control
 		RobotMap.Component.driverXbox.x


### PR DESCRIPTION
Added a button (`y`) to wiggle the robot for putting the gear on the peg. Still allows for drive control on top of the wiggle.