### PR TITLE
Tuned auton constant

### DIFF
--- a/src/org/usfirst/frc4904/robot/autonomous/strategies/AutonGearLoadPegTime.java
+++ b/src/org/usfirst/frc4904/robot/autonomous/strategies/AutonGearLoadPegTime.java
@@ -11,7 +11,7 @@ import edu.wpi.first.wpilibj.command.CommandGroup;
 import edu.wpi.first.wpilibj.command.WaitCommand;
 
 public class AutonGearLoadPegTime extends CommandGroup {
-	public static final double TIME_INITIAL_APPROACH_1 = 1.8;
+	public static final double TIME_INITIAL_APPROACH_1 = 1.6;
 	public static final double TIME_TURN = 1;
 	public static final double TIME_INITIAL_APPROACH_2 = 1;
 


### PR DESCRIPTION
Reduce load-side peg initial path time by 0.2 seconds.